### PR TITLE
fix: avoid syntax collision with self-invoking function

### DIFF
--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -148,13 +148,13 @@ export const run = (env: WebWorkerEnvironment, scriptContent: string, scriptUrl?
   env.$runWindowLoadEvent$ = 1;
 
   // First we want to replace all `this` symbols
-  let sourceWithReplacedThis = replaceThisInSource(scriptContent, '(thi$(this)?window:this)');
+  let sourceWithReplacedThis = replaceThisInSource(scriptContent, 'getThi$(this)');
 
   scriptContent =
     `with(this){${sourceWithReplacedThis.replace(
       /\/\/# so/g,
       '//Xso'
-    )}\n;function thi$(t){return t===this}};${(webWorkerCtx.$config$.globalFns || [])
+    )}\n;function getThi$(t){return t===this?window:this}};${(webWorkerCtx.$config$.globalFns || [])
       .filter((globalFnName) => /[a-zA-Z_$][0-9a-zA-Z_$]*/.test(globalFnName))
       .map((g) => `(typeof ${g}=='function'&&(this.${g}=${g}))`)
       .join(';')};` + (scriptUrl ? '\n//# sourceURL=' + scriptUrl : '');


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently, the [replacement of `this`](https://github.com/BuilderIO/partytown/blob/main/src/lib/web-worker/worker-exec.ts#L151) symbol includes an expression wrapped with braces. It might cause an incorrect syntax if the _previous function declaration has no semicolon_ at the end

Example: `setupUid2Sdk` is called immediately
![image](https://github.com/user-attachments/assets/fce4e01f-66a5-4b2e-9703-3edbab1a2ba2)

I suggest an adjustment to avoid syntax collision in 3rd party scripts since we have no control over those scripts. Instead of an expression in braces, we can encapsulate this logic using a function

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
