### PR TITLE
docs: use dummy web property ID

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -75,7 +75,7 @@ Putting it together with the previous changes, our `+layout.svelte` looks like:
 
 	{@html '<script>' + partytownSnippet() + '</script>'}
 
-	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-ZX7H2KPXNZ"></script>
+	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
 	<script type="text/partytown">
 		window.dataLayer = window.dataLayer || [];
 		window.gtag = function(){dataLayer.push(arguments);}

--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -75,12 +75,12 @@ Putting it together with the previous changes, our `+layout.svelte` looks like:
 
 	{@html '<script>' + partytownSnippet() + '</script>'}
 
-	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=YOUR-ID-HERE"></script>
 	<script type="text/partytown">
 		window.dataLayer = window.dataLayer || [];
 		window.gtag = function(){dataLayer.push(arguments);}
 		gtag('js', new Date());
-		gtag('config', 'G-XXXXXXXXXX');
+		gtag('config', 'YOUR-ID-HERE');
 	</script>
 </svelte:head>
 ```

--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -80,7 +80,7 @@ Putting it together with the previous changes, our `+layout.svelte` looks like:
 		window.dataLayer = window.dataLayer || [];
 		window.gtag = function(){dataLayer.push(arguments);}
 		gtag('js', new Date());
-		gtag('config', 'G-ZX7H2KPXNZ');
+		gtag('config', 'G-XXXXXXXXXX');
 	</script>
 </svelte:head>
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I'd prefer not to have my real web property ID listed there. Looks like I accidentally included it in an earlier docs change :laughing: 

# Use cases and why

So other people don't accidentally send their traffic to my analytics account

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
