### PR TITLE
docs: clarified that the `worker` strategy is not supported with app directory

### DIFF
--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -8,6 +8,8 @@ The Next.js setup is largely the same as the [React integration guide](/react), 
 
 The Next.js `<Script/>` component provides an experimental `worker` strategy, which uses Partytown under-the-hood. Please see the Next.js [Script documentation](https://nextjs.org/docs/api-reference/next/script#worker) for more information.
 
+> Note: The `worker` strategy is currently unsupported with the Next.js 13+ `app` directory.
+
 --- 
 > Below are the instructions if you are not using the experimental [Worker Strategy](#worker-strategy).
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Added clarification that the `worker` strategy is currently unsupported with the next.js `app` directory.

# Use cases and why

It's not currently clear that partytown won't work with the next.js `app` directory

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
