### PR TITLE
fix: add ability to use partytown with scripts with relative paths

### DIFF
--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -32,7 +32,7 @@ export function snippet(
         libPath = (config!.lib || '/~partytown/') + (config!.debug ? 'debug/' : '');
       }
 
-      if (libPath[0] == '/') {
+      if (libPath[0] == '/' || libPath[0] == '.') {
         // grab all the partytown scripts
         scripts = doc.querySelectorAll('script[type="text/partytown"]');
 
@@ -72,7 +72,7 @@ export function snippet(
           }
         }
       } else if (debug) {
-        console.warn('Partytown config.lib url must start with "/"');
+        console.warn('Partytown config.lib url must start with "/" or "."');
       }
     }
   }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Hi. Thanks for your cool project!

I am currently having a problem when using the script on sites with relative paths. The site I'm working on is published on different domains and has different paths.

For this reason I currently have to use a hack in my Rspack config:

```js
partytownSnippet: partytownSnippet({
  lib: './',
}).replace('"/"', '"."'),
```

The current PR adds the ability to use it with relative paths.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
