### PR TITLE
ci: upgrade pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

It seems pnpm installation currently not works:
https://github.com/BuilderIO/partytown/actions/runs/11243169210/job/31258440384?pr=631

v2 not working anymore:
https://github.com/pnpm/action-setup?tab=readme-ov-file#warning-upgrade-from-v2

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
