### PR TITLE
fix: (worker-window): polyfill CSSMediaRule - copy from the PR #614

### DIFF
--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -354,6 +354,7 @@ export const createWindow = (
         patchDocumentElementChild(win.HTMLBodyElement, env);
         patchHTMLHtmlElement(win.HTMLHtmlElement, env);
         createCSSStyleSheetConstructor(win, 'CSSStyleSheet');
+        createCSSStyleSheetConstructor(win, 'CSSMediaRule');
 
         definePrototypeNodeType(win.Comment, 8);
         definePrototypeNodeType(win.DocumentType, 10);

--- a/tests/integrations/clarity/index.html
+++ b/tests/integrations/clarity/index.html
@@ -22,28 +22,6 @@
   </script>
   <script src='/~partytown/debug/partytown.js'></script>
 
-  <script>
-    const observer = new MutationObserver(mutations => {
-      mutations.forEach(({ addedNodes }) => {
-        addedNodes.forEach(node => {
-          // For each added script tag
-          if (node.nodeType === 1 && node.tagName === 'SCRIPT') {
-            const src = node.src || '';
-            if (node.src.includes('clarity.js')) {
-              node.type = 'text/partytown';
-              node.src = './clarity.bundle.js';
-            }
-          }
-        });
-      });
-    });
-    // Starts the monitoring
-    observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
-  </script>
-
   <style>
       body {
           font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
This PR is a copy from https://github.com/BuilderIO/partytown/pull/614 that PR should go in because third-parties like clarity are still broken
Include polyfill for CSSMediaRule (used by hubspot tracking js)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->
error when using clarity:
![image](https://github.com/user-attachments/assets/90231b7f-fd2a-4698-af12-8feede99d4a7)

1. Use Case:
Hubspot references CSSMediaRule in their JS and it is currently failing because it doesn't exist in worker context.
We already have the polyfill for CSSStyleSheet and CSSMediaRule has the same interface so the same polyfill should work!
# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
