### PR TITLE
docs: making install commands consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4.0.2

--- a/docs/angular.md
+++ b/docs/angular.md
@@ -9,7 +9,9 @@ To setup Partytown in an Angular project take the following steps.
 Run the command below to install the dependencies
 
 ```bash
-npm install @builder.io/partytown # or yarn add @builder.io/partytown
+npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 Add the path to the Partytown JS files into the assets array in your `angular.json` file

--- a/docs/astro.md
+++ b/docs/astro.md
@@ -9,7 +9,9 @@ There is a first-class [Astro integration for partytown](https://github.com/with
 Astro includes a CLI tool for adding integrations. Using the `astro add` command will automatically install Partytown and configure your project.
 
 ```bash
-yarn astro add partytown # or npx astro add partytown
+npx astro add partytown
+yarn astro add partytown
+pnpx astro add partytown
 ```
 
 ## Partytown Script

--- a/docs/gatsby.md
+++ b/docs/gatsby.md
@@ -10,6 +10,8 @@ For additional information, please see [How to Add Google Analytics gtag to Gats
 
 ```bash
 npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 ## Configure

--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -14,7 +14,9 @@ The Next.js `<Script/>` component provides an experimental `worker` strategy, wh
 ## Install
 
 ```bash
-npm install "@builder.io/partytown"
+npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 ## Configure

--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -9,7 +9,9 @@ There is a first-class [Nuxt integration for partytown](https://github.com/nuxt-
 Add `@nuxtjs/partytown` dependency to your project.
 
 ```bash
-yarn add --dev @nuxtjs/partytown # or npm install --save-dev @nuxtjs/partytown
+npm install --save-dev @nuxtjs/partytown
+yarn add --dev @nuxtjs/partytown
+pnpm install --save-dev @nuxtjs/partytown
 ```
 
 ## Configure

--- a/docs/react.md
+++ b/docs/react.md
@@ -8,6 +8,8 @@ The Partytown NPM package already comes with a React component, which is a thin 
 
 ```bash
 npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 ## Configure

--- a/docs/remix.md
+++ b/docs/remix.md
@@ -8,6 +8,8 @@ The Remix setup is largely the same as the [React integration guide](/react), ex
 
 ```bash
 npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 ## Configure

--- a/docs/shopify-hydrogen.md
+++ b/docs/shopify-hydrogen.md
@@ -8,6 +8,8 @@ The [Shopify Hydrogen](https://hydrogen.shopify.dev/) setup is largely the same 
 
 ```bash
 npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
 ```
 
 ## Configure

--- a/docs/solid.md
+++ b/docs/solid.md
@@ -4,7 +4,13 @@ title: Solid
 
 To setup Partytown in an Solid project take the following steps.
 
-## Installation
+## Install
+
+```bash
+npm install @builder.io/partytown
+yarn add @builder.io/partytown
+pnpm install @builder.io/partytown
+```
 
 Use your favorite package manager to install `@builder.io/partytown` dependency and
 copy the Partytown files to the local filesystem using the Vite plugin.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

While browsing the docs I noticed that the installation commands were not consistent through the "Integrations" section. Some pages say to use NPM, some Yarn, some both...one page even had quotes around the package name which is redundant.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
