### PR TITLE
fix(docs): escape tilde expansion in copy task command instruction

### DIFF
--- a/docs/src/routes/copy-library-files/index.mdx
+++ b/docs/src/routes/copy-library-files/index.mdx
@@ -15,7 +15,7 @@ You can also use the [lib config](/configuration) if your site must host these f
 For convenience, the Partytown CLI provides a `copylib` task. The last argument should be the directory where the Partytown lib files should be copied to. In the example below, the lib files are copying to the directory `public/~partytown`, relative to the current working directory:
 
 ```bash
-partytown copylib public/~partytown
+partytown copylib 'public/~partytown'
 ```
 
 This command can be used before a build script. Below is an example of copying the Partytown lib files before a Nextjs build command, using npm scripts:
@@ -24,7 +24,7 @@ This command can be used before a build script. Below is an example of copying t
 {
   "scripts": {
     "build": "npm run partytown && next build",
-    "partytown": "partytown copylib public/~partytown"
+    "partytown": "partytown copylib 'public/~partytown'"
   }
 }
 ```


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

If I try to copy the library files by following the instructions in the [docs](https://partytown.builder.io/copy-library-files), then [Deno](https://deno.com/) throws the following error:

```sh
deno task partytown
Task partytown partytown copylib public/~partytown
error: Error parsing script 'partytown'.

Caused by:
    Unexpected character.
      ~partytown
      ~
``` 

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Deno supports running npm scripts natively with the [deno task](https://docs.deno.com/runtime/reference/cli/task_runner/) subcommand. But in the case of Partytown, the `~` in the default path is causing a [tilde expansion](https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html), erroring out Deno CLI.

To fix this, you can pass the path in [single quotes](https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html), effectively escaping the `~`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality **N/A**
