### PR TITLE
chore: update prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "gzip-size": "^6.0.0",
     "np": "^7.6.1",
     "playwright": "^1.48.2",
-    "prettier": "^2.6.0",
+    "prettier": "^3.5.3",
     "pretty-quick": "^4.0.0",
     "rollup": "^3.29.1",
     "simple-git-hooks": "^2.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,11 +58,11 @@ importers:
         specifier: ^1.48.2
         version: 1.48.2
       prettier:
-        specifier: ^2.6.0
-        version: 2.8.8
+        specifier: ^3.5.3
+        version: 3.5.3
       pretty-quick:
         specifier: ^4.0.0
-        version: 4.0.0(prettier@2.8.8)
+        version: 4.0.0(prettier@3.5.3)
       rollup:
         specifier: ^3.29.1
         version: 3.29.4
@@ -939,6 +939,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@2.1.0:
     resolution: {integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==}
@@ -1058,6 +1059,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1287,9 +1289,11 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -1634,6 +1638,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-quick@4.0.0:
     resolution: {integrity: sha512-M+2MmeufXb/M7Xw3Afh1gxcYpj+sK0AxEfnfF958ktFeAyi5MsKY5brymVURQLgPLV1QaF5P4pb2oFJ54H3yzQ==}
     engines: {node: '>=14'}
@@ -1736,6 +1745,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@3.29.4:
@@ -3763,7 +3773,9 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  pretty-quick@4.0.0(prettier@2.8.8):
+  prettier@3.5.3: {}
+
+  pretty-quick@4.0.0(prettier@3.5.3):
     dependencies:
       execa: 5.1.1
       find-up: 5.0.0
@@ -3771,7 +3783,7 @@ snapshots:
       mri: 1.2.0
       picocolors: 1.1.1
       picomatch: 3.0.1
-      prettier: 2.8.8
+      prettier: 3.5.3
       tslib: 2.6.2
 
   pump@3.0.0:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,7 +36,7 @@ export type MessageFromWorkerToSandbox =
       type: WorkerMessageType.InitializedEnvironmentScript,
       winid: WinId,
       instanceId: InstanceId,
-      errorMsg: string
+      errorMsg: string,
     ]
   | [type: WorkerMessageType.InitializeNextScript, winId: WinId]
   | [type: WorkerMessageType.ForwardWorkerAccessRequest, accessReq: MainAccessRequest]
@@ -57,7 +57,7 @@ export type MessageFromSandboxToWorker =
       winId: WinId,
       instanceId: InstanceId,
       callbackName: string,
-      args: any[]
+      args: any[],
     ];
 
 export const enum WorkerMessageType {
@@ -305,7 +305,7 @@ export type SerializedCSSRuleListTransfer = [SerializedType.CSSRuleList, Seriali
 
 export type SerializedCSSStyleDeclarationTransfer = [
   SerializedType.CSSStyleDeclaration,
-  { [key: string]: SerializedTransfer | undefined }
+  { [key: string]: SerializedTransfer | undefined },
 ];
 
 export type SerializedErrorTransfer = [SerializedType.Error, Error];
@@ -318,12 +318,12 @@ export type SerializedInstanceTransfer = [SerializedType.Instance, SerializedIns
 
 export type SerializedNodeListTransfer = [
   SerializedType.NodeList,
-  (SerializedTransfer | undefined)[]
+  (SerializedTransfer | undefined)[],
 ];
 
 export type SerializedObjectTransfer = [
   SerializedType.Object,
-  { [key: string]: SerializedTransfer | undefined }
+  { [key: string]: SerializedTransfer | undefined },
 ];
 
 export type SerializedAttr = [string, string];
@@ -374,7 +374,7 @@ export type SerializedInstance =
        * Node name for Node instances
        */
       type: string,
-      type?: string
+      type?: string,
     ];
 
 /**
@@ -713,7 +713,7 @@ export type LazyBridge = [
   RandomId,
   typeof WinIdKey,
   typeof InstanceIdKey,
-  typeof ApplyPathKey
+  typeof ApplyPathKey,
 ];
 
 export type InitWindowMedia = (

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -187,8 +187,8 @@ export const createWindow = (
           const NodeCstr = nodeCstrs[nodeName]
             ? nodeCstrs[nodeName]
             : nodeName.includes('-')
-            ? nodeCstrs.UNKNOWN
-            : nodeCstrs.I;
+              ? nodeCstrs.UNKNOWN
+              : nodeCstrs.I;
 
           cstrInstanceId = instanceId;
           cstrNodeName = nodeName;
@@ -213,10 +213,10 @@ export const createWindow = (
             const SuperCstr = TrapConstructors[cstrName]
               ? WorkerTrapProxy
               : superCstrName === 'EventTarget'
-              ? WorkerEventTargetProxy
-              : superCstrName === 'Object'
-              ? WorkerBase
-              : win[superCstrName];
+                ? WorkerEventTargetProxy
+                : superCstrName === 'Object'
+                  ? WorkerBase
+                  : win[superCstrName];
 
             const Cstr = (win[cstrName] = defineConstructorName(
               interfaceType === InterfaceType.EnvGlobalConstructor


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Update the prettier dependency. 

# Use cases and why

Currently `npm install` on `main` gives these errors

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @qwik.dev/partytown@0.11.0
npm ERR! Found: prettier@2.8.8
npm ERR! node_modules/prettier
npm ERR!   dev prettier@"^2.6.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer prettier@"^3.0.0" from pretty-quick@4.1.1
npm ERR! node_modules/pretty-quick
npm ERR!   dev pretty-quick@"^4.0.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
```

I've simply updated the prettier dependency and diffed the output from `npm run fmt` before and after, observing no differences.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
