### PR TITLE
fix: Add adoptedStyleSheets.get() to patched `document` in worker.

### DIFF
--- a/.changeset/chilly-eggs-yawn.md
+++ b/.changeset/chilly-eggs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/partytown': patch
+---
+
+Add adoptedStyleSheets.get() to patched `document` in worker.

--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -179,6 +179,12 @@ export const patchDocument = (
       },
     },
 
+    adoptedStyleSheets: {
+      get() {
+        return getter(this, ['adoptedStyleSheets']);
+      },
+    },
+
     implementation: {
       get() {
         return {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Clarity is trying to access `document.adoptedStyleSheets` in the worker, which returns an array of strings:
![Screenshot 2025-05-19 at 13 29 08](https://github.com/user-attachments/assets/ee97c6a3-8372-4c1d-8dec-6d2d4fb41268)

#666 

# Use cases and why

- 1. When accessing document.adoptedStyleSheets, should get the actual value

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

I have checked the http://localhost:4000/tests/integrations/clarity/ test before and after the fix.

I can confirm that before the fix, the error was present (after some time):
![Screenshot 2025-05-19 at 13 47 58](https://github.com/user-attachments/assets/0f45ea18-3756-4e80-a641-fb2ea13120c2)

And after the fix, Clarity seems to work and no error was present (even after some time spent on the page):
![Screenshot 2025-05-19 at 13 53 59](https://github.com/user-attachments/assets/2f15d683-330a-4f01-99dc-405ea7bc55da)
