### PR TITLE
feat: Create a compiled release package

### DIFF
--- a/.changeset/funny-monkeys-grin.md
+++ b/.changeset/funny-monkeys-grin.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/partytown': minor
+---
+
+feat: Creates a compiled release of the lib directory.
+
+This creates a compiled release of the `lib` directory for use by integration builders and HTML-only developers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,14 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tar and gzip the lib directory
+        shell: bash
+        run: tar -zcvf lib.tar lib && gzip lib.tar
+
+      - name: Upload release asset
+        user: actions4gh/setup-gh@v1
+        if: github.ref_type == 'tag'
+        run : gh release ${{ github.ref }} upload './lib.tar.gz#Compiled lib'
+        env:
+          GH_REPO: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ node_modules/
 .idea
 .history
 tests/integrations/load-scripts-on-main-thread/snippet.js
+lib.tar.gz


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This is an initial step towards resolving https://github.com/QwikDev/partytown/issues/680.

This pull request adds a build step onto the `build.prod` command that creates a `lib.tar.gz` file with the compiled code, but is gitignored, so it doesn't make its way back into the repo.

What is missing is a github/changeset step that uploads that file to the tagged github release. This is something I don't have good insight on. The changeset build step uploads the compiled code to npm. When I test this build process on my fork, the ci jobs fail because I don't have access to the npm pipeline, which is good. However, it makes it hard to debug this.

This issue https://github.com/changesets/changesets/discussions/1366 seems to offer a solid guide on how to do this using a separate action. 

# Use cases and why
Resolves an ongoing issue where the partytown library is not released via github as a compiled asset.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
